### PR TITLE
[FEATURE]  new option allowDoubleVarnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var sassdoc        = require('sassdoc');
  * @param {string[]} options.imports - Sass files to load with `@import`.
  * @param {string[]} options.sort - Custom sort order for component sections.
  * @param {boolean} options._foundationShim - Adds the `@include add-foundation-colors` shim for Foundation for Sites 6.2.
+ * @param {boolean} options.allowDoubleVarnames - if `false` only the first occuring of a variable name is used. Allows overwriting of variable names that occur later in the queue.
  * @param {function} cb - Function to run when the settings file has been written to disk.
  */
 module.exports = function(files, options, cb) {
@@ -26,7 +27,8 @@ module.exports = function(files, options, cb) {
     groups: {},
     imports: [],
     sort: [],
-    _foundationShim: false
+    _foundationShim: false,
+    allowDoubleVarnames: true
   }, options);
 
   if (typeof files === 'string') {
@@ -58,10 +60,10 @@ module.exports = function(files, options, cb) {
     // Generate each component section
     var n = 1;
     for (var i in data) {
-      outputStream.write(buildSection(i, n, data[i], options._foundationShim));
+      outputStream.write(buildSection(i, n, data[i], options._foundationShim, options.allowDoubleVarnames));
       n++;
     }
 
     cb();
   }
-}
+};

--- a/lib/buildSection.js
+++ b/lib/buildSection.js
@@ -1,6 +1,7 @@
 var buildVariable = require('./buildVariable');
 var format        = require('util').format;
 var repeat        = require('repeat-string');
+var usedNames     = {};
 
 /**
  * Builds a complete section of the settings file, which includes a title area, and a list of variables.
@@ -8,9 +9,10 @@ var repeat        = require('repeat-string');
  * @param {integer} num - The number of the section, which is added before the title text.
  * @param {object[]} component - A set of SassDoc variable definitions, which contain info about each variable's name and value.
  * @param {boolean} shim - If `true`, a reference to the mixin `add-foundation-colors()` is added in the "Global Stlyes" section. This is needed for the Foundation for Sites settings file to work correctly.
+ * @param {boolean} allowDoubleVarnames - If `true`, double variable names are allowed. if `false` only the first occuring of a variable name is used. Allows overwriting of variable names that occur later in the queue.
  * @returns {string} A formatted section.
  */
-module.exports = function(name, num, component, shim) {
+module.exports = function(name, num, component, shim, allowDoubleVarnames) {
   var output = '';
   var title = format('%d. %s', num, name);
 
@@ -18,7 +20,11 @@ module.exports = function(name, num, component, shim) {
 
   // Iterate through each variable within the component
   for (var i in component) {
-    output += buildVariable(component[i]);
+    var variable = component[i];
+    if (allowDoubleVarnames || !(variable.context.name in usedNames)) {
+      usedNames[variable.context.name] = 1;
+      output += buildVariable(component[i]);
+    }
   }
 
   if (shim && name == 'Global') {
@@ -28,4 +34,4 @@ module.exports = function(name, num, component, shim) {
   output += '\n';
 
   return output;
-}
+};


### PR DESCRIPTION
 default = true
 If `true`, double variable names are allowed.
 if `false` only the first occuring of a variable name is used. Allows the overwriting of variable names that occur later in the sass file queue.

You can prepare a sass file with variables and can sort it to the first position. So you can overwrite other variable name definitions. 
